### PR TITLE
Fix compat handlers not running

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
     "preLaunch": [
       "artifacts.ArtifactsPreLaunch"
     ],
-    "artifacts-compathandlers": [
+    "artifacts:compat_handlers": [
       "artifacts.common.compat.HaemaCompat",
       "artifacts.common.compat.OriginsCompat"
     ],


### PR DESCRIPTION
I was playing Haema with a friend and she recalled that the umbrella used to block the sunlight for vampires but didn't seem to be working anymore.

The entrypoint key was [`artifacts-compathandlers` in `fabric.mod.json`](https://github.com/florensie/artifacts-fabric/blob/c6900552d7a5505624baf2fa6bcfee5b3d989467/src/main/resources/fabric.mod.json#L31) but in the code it was looking for the key [`artifacts:compat_handlers`](https://github.com/florensie/artifacts-fabric/blob/c6900552d7a5505624baf2fa6bcfee5b3d989467/src/main/java/artifacts/Artifacts.java#L58).

This PR updates the entrypoint key in `fabric.mod.json` to match the one in the code.